### PR TITLE
Update README for FastAPI database info

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,17 @@ Ejecuta la interfaz de ejemplo con:
 ```bash
 streamlit run frontend/main.py
 ```
+
+## Backend
+
+Inicia la API desde la carpeta `backend`:
+
+```bash
+cd backend && uvicorn main:app --reload
+```
+
+El archivo `database/questions.db` se creará automáticamente la primera vez que se ejecute la aplicación.
+
 =======
 ## Relleno de la base de datos
 
@@ -42,4 +53,5 @@ python3 tests/seed_questions.py
 
 Esto creará el archivo `database/questions.db` (ignorado en Git) y
 poblará su contenido con datos de ejemplo.
+Si el archivo no existe, también se generará automáticamente al arrancar el backend.
 

--- a/backend/README.md
+++ b/backend/README.md
@@ -2,8 +2,10 @@
 
 Implementación de la API y la lógica de negocio en **FastAPI**.
 
-Para iniciar el servidor de desarrollo:
+Para iniciar el servidor de desarrollo ejecuta `uvicorn` desde esta carpeta:
 
 ```bash
-uvicorn main:app --reload
+cd backend && uvicorn main:app --reload
 ```
+
+El archivo de base de datos `database/questions.db` se creará automáticamente la primera vez que inicies la API.


### PR DESCRIPTION
## Summary
- explain that `database/questions.db` is created on startup
- run `uvicorn` from the `backend` directory

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6848434309788333ab64338abf0a0f27